### PR TITLE
Directly change the semantic exit to hostio require(0) in zkWASM

### DIFF
--- a/src/runtime/os_wasip1.go
+++ b/src/runtime/os_wasip1.go
@@ -49,7 +49,11 @@ type iovec struct {
 func require(code int32)
 
 func exit(code int32) {
-	require(0)
+	if code == 0 {
+		wasmPause()
+	} else {
+		require(0)
+	}
 }
 
 //go:wasmimport wasi_snapshot_preview1 args_get

--- a/src/runtime/os_wasip1.go
+++ b/src/runtime/os_wasip1.go
@@ -49,6 +49,11 @@ type iovec struct {
 func require(code int32)
 
 func exit(code int32) {
+	// For a normal exit, we call wasmPause(), it will not immediately exit, it just sets global var PAUSE to nonzero
+	// so that goroutine would exit mainloop
+	// For any code other than 0, it indicates an error. For target zkWASM, we call zkWASM predefined hostio require(0)
+	// to marks it abnormal. It serves like assertion and it would immediately invalid proving circuit and exit in
+	// zkWASM runtime. Thus all cases have been covered.
 	if code == 0 {
 		wasmPause()
 	} else {

--- a/src/runtime/os_wasip1.go
+++ b/src/runtime/os_wasip1.go
@@ -45,8 +45,11 @@ type iovec struct {
 	bufLen size
 }
 
+//go:wasmimport env require
+func require(code int32)
+
 func exit(code int32) {
-	return
+	require(0)
 }
 
 //go:wasmimport wasi_snapshot_preview1 args_get

--- a/src/syscall/os_wasip1.go
+++ b/src/syscall/os_wasip1.go
@@ -5,5 +5,5 @@
 package syscall
 
 func ProcExit(code int32) {
-	return
+	require(0)
 }

--- a/src/syscall/os_wasip1.go
+++ b/src/syscall/os_wasip1.go
@@ -5,5 +5,9 @@
 package syscall
 
 func ProcExit(code int32) {
-	require(0)
+	if code == 0 {
+		wasmPause()
+	} else {
+		require(0)
+	}
 }

--- a/src/syscall/os_wasip1.go
+++ b/src/syscall/os_wasip1.go
@@ -5,9 +5,5 @@
 package syscall
 
 func ProcExit(code int32) {
-	if code == 0 {
-		wasmPause()
-	} else {
-		require(0)
-	}
+	return
 }


### PR DESCRIPTION
Directly change the semantic exit to hostio require(0) in zkWASM

Arguement is:
In a normal exit, goroutine set var `PAUSE` to nozero to end the current
main thread and an accident exit, the runtime `exit` is chosen.
    
So our change for a normal hostio exit, we set PAUSE to 1 to directly exit.
For WASM, the exit now is only for abnormal exit, which includes panic.
So we use zkWASM hostio `require` with input 0 marks it is abnormal and
needs exit