### PR TITLE
add build tag math_pure_go

### DIFF
--- a/src/math/acos_s390x.s
+++ b/src/math/acos_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // Minimax polynomial coefficients and other constants

--- a/src/math/acosh_s390x.s
+++ b/src/math/acosh_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // Minimax polynomial coefficients and other constants

--- a/src/math/arith_s390x.go
+++ b/src/math/arith_s390x.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 package math
 
 import "internal/cpu"

--- a/src/math/asin_s390x.s
+++ b/src/math/asin_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // Minimax polynomial coefficients and other constants

--- a/src/math/asinh_s390x.s
+++ b/src/math/asinh_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // Minimax polynomial coefficients and other constants

--- a/src/math/atan2_s390x.s
+++ b/src/math/atan2_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 #define PosInf		0x7FF0000000000000

--- a/src/math/atan_s390x.s
+++ b/src/math/atan_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // Minimax polynomial coefficients and other constants

--- a/src/math/atanh_s390x.s
+++ b/src/math/atanh_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // Minimax polynomial coefficients and other constants

--- a/src/math/cbrt_s390x.s
+++ b/src/math/cbrt_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // Minimax polynomial coefficients and other constants

--- a/src/math/cosh_s390x.s
+++ b/src/math/cosh_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // Constants

--- a/src/math/dim_amd64.s
+++ b/src/math/dim_amd64.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 #define PosInf 0x7FF0000000000000

--- a/src/math/dim_arm64.s
+++ b/src/math/dim_arm64.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 #define PosInf 0x7FF0000000000000

--- a/src/math/dim_asm.go
+++ b/src/math/dim_asm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build amd64 || arm64 || riscv64 || s390x
+//go:build !math_pure_go && (amd64 || arm64 || riscv64 || s390x)
 
 package math
 

--- a/src/math/dim_noasm.go
+++ b/src/math/dim_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !amd64 && !arm64 && !riscv64 && !s390x
+//go:build math_pure_go || (!amd64 && !arm64 && !riscv64 && !s390x)
 
 package math
 

--- a/src/math/dim_riscv64.s
+++ b/src/math/dim_riscv64.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // Values returned from an FCLASS instruction.

--- a/src/math/dim_s390x.s
+++ b/src/math/dim_s390x.s
@@ -4,6 +4,8 @@
 
 // Based on dim_amd64.s
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 #define PosInf 0x7FF0000000000000

--- a/src/math/erf_s390x.s
+++ b/src/math/erf_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // Minimax polynomial coefficients and other constants

--- a/src/math/erfc_s390x.s
+++ b/src/math/erfc_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 #define Neg2p11 0xC000E147AE147AE1

--- a/src/math/exp2_asm.go
+++ b/src/math/exp2_asm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build arm64
+//go:build !math_pure_go && arm64
 
 package math
 

--- a/src/math/exp2_noasm.go
+++ b/src/math/exp2_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !arm64
+//go:build math_pure_go || !arm64
 
 package math
 

--- a/src/math/exp_amd64.go
+++ b/src/math/exp_amd64.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build amd64
+//go:build !math_pure_go && amd64
 
 package math
 

--- a/src/math/exp_amd64.s
+++ b/src/math/exp_amd64.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // The method is based on a paper by Naoki Shibata: "Efficient evaluation

--- a/src/math/exp_arm64.s
+++ b/src/math/exp_arm64.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #define	Ln2Hi	6.93147180369123816490e-01
 #define	Ln2Lo	1.90821492927058770002e-10
 #define	Log2e	1.44269504088896338700e+00

--- a/src/math/exp_asm.go
+++ b/src/math/exp_asm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build amd64 || arm64 || s390x
+//go:build !math_pure_go && (amd64 || arm64 || s390x)
 
 package math
 

--- a/src/math/exp_noasm.go
+++ b/src/math/exp_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !amd64 && !arm64 && !s390x
+//go:build math_pure_go || (!amd64 && !arm64 && !s390x)
 
 package math
 

--- a/src/math/exp_s390x.s
+++ b/src/math/exp_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // Minimax polynomial approximation and other constants

--- a/src/math/expm1_s390x.s
+++ b/src/math/expm1_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // Minimax polynomial approximation and other constants

--- a/src/math/floor_386.s
+++ b/src/math/floor_386.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // func archCeil(x float64) float64

--- a/src/math/floor_amd64.s
+++ b/src/math/floor_amd64.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 #define Big		0x4330000000000000 // 2**52

--- a/src/math/floor_arm64.s
+++ b/src/math/floor_arm64.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // func archFloor(x float64) float64

--- a/src/math/floor_asm.go
+++ b/src/math/floor_asm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build 386 || amd64 || arm64 || ppc64 || ppc64le || s390x || wasm
+//go:build !math_pure_go && (386 || amd64 || arm64 || ppc64 || ppc64le || s390x || wasm)
 
 package math
 

--- a/src/math/floor_noasm.go
+++ b/src/math/floor_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !386 && !amd64 && !arm64 && !ppc64 && !ppc64le && !s390x && !wasm
+//go:build math_pure_go || (!386 && !amd64 && !arm64 && !ppc64 && !ppc64le && !s390x && !wasm)
 
 package math
 

--- a/src/math/floor_ppc64x.s
+++ b/src/math/floor_ppc64x.s
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build ppc64 || ppc64le
+//go:build !math_pure_go && (ppc64 || ppc64le)
+// +build !math_pure_go
 // +build ppc64 ppc64le
 
 #include "textflag.h"

--- a/src/math/floor_s390x.s
+++ b/src/math/floor_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // func archFloor(x float64) float64

--- a/src/math/floor_wasm.s
+++ b/src/math/floor_wasm.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 TEXT ·archFloor(SB),NOSPLIT,$0

--- a/src/math/hypot_386.s
+++ b/src/math/hypot_386.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // func archHypot(p, q float64) float64

--- a/src/math/hypot_amd64.s
+++ b/src/math/hypot_amd64.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 #define PosInf 0x7FF0000000000000

--- a/src/math/hypot_asm.go
+++ b/src/math/hypot_asm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build 386 || amd64
+//go:build !math_pure_go && (386 || amd64)
 
 package math
 

--- a/src/math/hypot_noasm.go
+++ b/src/math/hypot_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !386 && !amd64
+//go:build math_pure_go || (!386 && !amd64)
 
 package math
 

--- a/src/math/log10_s390x.s
+++ b/src/math/log10_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // Minimax polynomial coefficients and other constants

--- a/src/math/log1p_s390x.s
+++ b/src/math/log1p_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // Constants

--- a/src/math/log_amd64.s
+++ b/src/math/log_amd64.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 #define HSqrt2 7.07106781186547524401e-01 // sqrt(2)/2

--- a/src/math/log_asm.go
+++ b/src/math/log_asm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build amd64 || s390x
+//go:build !math_pure_go && (amd64 || s390x)
 
 package math
 

--- a/src/math/log_s390x.s
+++ b/src/math/log_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // Minimax polynomial approximations

--- a/src/math/log_stub.go
+++ b/src/math/log_stub.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !amd64 && !s390x
+//go:build math_pure_go || (!amd64 && !s390x)
 
 package math
 

--- a/src/math/modf_arm64.s
+++ b/src/math/modf_arm64.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // func archModf(f float64) (int float64, frac float64)

--- a/src/math/modf_asm.go
+++ b/src/math/modf_asm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build arm64 || ppc64 || ppc64le
+//go:build !math_pure_go && (arm64 || ppc64 || ppc64le)
 
 package math
 

--- a/src/math/modf_noasm.go
+++ b/src/math/modf_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !arm64 && !ppc64 && !ppc64le
+//go:build math_pure_go || (!arm64 && !ppc64 && !ppc64le)
 
 package math
 

--- a/src/math/modf_ppc64x.s
+++ b/src/math/modf_ppc64x.s
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build ppc64 || ppc64le
+//go:build !math_pure_go && (ppc64 || ppc64le)
+// +build !math_pure_go
 // +build ppc64 ppc64le
 
 #include "textflag.h"

--- a/src/math/pow_s390x.s
+++ b/src/math/pow_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 #define PosInf   0x7FF0000000000000

--- a/src/math/sin_s390x.s
+++ b/src/math/sin_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // Various constants
@@ -73,6 +75,10 @@ TEXT ·sinAsm(SB),NOSPLIT,$0-16
 	BLTU    L17
 	FMOVD   F0, F5
 L2:
+	MOVD    $sincosxlim<>+0(SB), R1
+	FMOVD   0(R1), F1
+	FCMPU   F5, F1
+	BGT     L16
 	MOVD    $sincoss7<>+0(SB), R1
 	FMOVD   0(R1), F4
 	MOVD    $sincoss6<>+0(SB), R1
@@ -205,6 +211,8 @@ L15:
 	RET
 
 
+L16:
+	BR     ·sin(SB)		//tail call
 sinIsZero:
 	FMOVD   F0, ret+8(FP)
 	RET
@@ -223,6 +231,10 @@ TEXT ·cosAsm(SB),NOSPLIT,$0-16
 	BLTU    L35
 	FMOVD   F0, F1
 L21:
+	MOVD    $sincosxlim<>+0(SB), R1
+	FMOVD   0(R1), F2
+	FCMPU   F1, F2
+	BGT     L30
 	MOVD    $sincosc7<>+0(SB), R1
 	FMOVD   0(R1), F4
 	MOVD    $sincosc6<>+0(SB), R1
@@ -354,3 +366,6 @@ L34:
 	FNEG    F0, F0
 	FMOVD   F0, ret+8(FP)
 	RET
+
+L30:
+	BR     ·cos(SB)		//tail call

--- a/src/math/sinh_s390x.s
+++ b/src/math/sinh_s390x.s
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
 
 #include "textflag.h"
 

--- a/src/math/stubs.go
+++ b/src/math/stubs.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !s390x
+//go:build math_pure_go || !s390x
 
 // This is a large group of functions that most architectures don't
 // implement in assembly.

--- a/src/math/stubs_s390x.s
+++ b/src/math/stubs_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 TEXT ·archLog10(SB), NOSPLIT, $0

--- a/src/math/tan_s390x.s
+++ b/src/math/tan_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // Minimax polynomial approximations
@@ -49,10 +51,9 @@ TEXT	·tanAsm(SB), NOSPLIT, $0-16
 	FMOVD	F0, F2
 L2:
 	MOVD	$·tanxlim<>+0(SB), R1
-	WORD	$0xED201000	//cdb	%f2,0(%r1)
-	BYTE	$0x00
-	BYTE	$0x19
-	BGE	L11
+	FMOVD	0(R1), F1
+	FCMPU	F2, F1
+	BGT	L9
 	BVS	L11
 	MOVD	$·tanxadd<>+0(SB), R1
 	FMOVD	88(R5), F6
@@ -105,6 +106,8 @@ L11:
 L10:
 	WORD	$0xB3130020	//lcdbr	%f2,%f0
 	BR	L2
+L9:
+	BR	·tan(SB)
 atanIsZero:
 	FMOVD	F0, ret+8(FP)
 	RET

--- a/src/math/tanh_s390x.s
+++ b/src/math/tanh_s390x.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !math_pure_go
+
 #include "textflag.h"
 
 // Minimax polynomial approximations


### PR DESCRIPTION
**Introduction**

In the current Go math package, when the architecture has a Floating-Point Unit (FPU), it accelerates floating-point computations using assembly code tailored to take advantage of the architecture's FPU. While this approach offers excellent performance, it creates compatibility issues with softfloat.  To support softfloat, we can use `-gcflags=all=-d=softfloat`, which can convert floating-point calculations to softfloat within the compiler, but it doesn't impact any assembly code in the math package. (The related issue can be found here: [[link to GitHub issue #62470](https://github.com/golang/go/issues/62470)](https://github.com/golang/go/issues/62470).)

To address this issue, we propose introducing a new build tag that disables the math package from utilizing FPU-related assembly code for performance optimization, thereby providing support for softfloat.

**Proposed Solution**

To support softfloat in the Go math package, we propose adding a new build tag, let's call it `math_pure_go`, that users can apply to disable the use of FPU-specific assembly code in the math package. We can use the `math_pure_go` build tag to disable the assembly in `math` package. With the build tag `-tags=math_pure_go` and `-gcflags=all=-d=softfloat`, we can support softfloat for all platforms.

```shell
go build -gcflags=all=-d=softfloat -tags=math_pure_go
```

**Benefit**

- This enhancement will make the Go math package compatible with softfloat, allowing Go to be used in environments or on architectures where hardware FPU support is not available or desired.
- Users who require softfloat support will be able to utilize the math package without encountering compatibility issues.
- The softfloat support is necessary in many scenarios, such as blockchain and cryptographic technologyies. 
  - In blockchain technology, where determinism and consistency are critical, using softfloat ensures consistent results across various platforms. This is crucial for achieving consensus among nodes in a decentralized network. 
  - Zero-knowledge proofs are cryptographic techniques that rely on precise and consistent mathematical operations. Softfloat support is essential for achieving consistent and predictable results when implementing zero-knowledge proof systems.
- The proposal aligns with Go's philosophy of providing flexibility and compatibility across various platforms and use cases.